### PR TITLE
Build broken, needs rust-embedded/meta-rust-bin

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -24,4 +24,5 @@
   <project remote="github" name="freescale/meta-freescale" path="sources/meta-freescale"/>
   <project remote="github" name="UpdateHub/meta-updatehub" path="sources/meta-updatehub"/>
   <project remote="oe" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="github" name="rust-embedded/meta-rust-bin" path="sources/meta-rust-bin" revision="b97048b5542878296cefe98671c80c1fcaad752e"/>
 </manifest>


### PR DESCRIPTION
Hello, this repo worked fine 4 months ago, but now it fails to compile with errors about "meta-rust-bin".

This change seems to fix it. Maybe you forgot to update the repo?

(but, why is this needed? Running rustc or cargo on the target doesn't make a lot of sense... And also why is ALSA, flac and libogg needed? Seem like a lot of bloat for an embedded image that adds to compile time...)

Also, the directory with the output images is now called `tmp-glibc` instead of `tmp`

Edit: The installer also doesn't autostart because the image is now based on SysVInit instead of SystemD and you are still copying in the systemd service...

why don't you have issues open on this repository?