### PR TITLE
README.org: Change repo init command to use dunfell branch

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,7 +53,7 @@ To download all sources run the following commands:
 #+BEGIN_SRC bash
   mkdir oel-platform
   cd oel-platform
-  repo init -u https://github.com/OSSystemsEmbeddedLinux/ossystems-embedded-linux-platform.git -b master
+  repo init -u https://github.com/OSSystemsEmbeddedLinux/ossystems-embedded-linux-platform.git -b dunfell
   repo sync
 #+END_SRC
 


### PR DESCRIPTION
Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>